### PR TITLE
Allow Const annotation only for immutable types

### DIFF
--- a/benchmark/benches/bench_query_readonly.jl
+++ b/benchmark/benches/bench_query_readonly.jl
@@ -13,7 +13,7 @@ function benchmark_query_posvel_mean_readonly(world, n)
     dy_sum = 0.0
     count = 0
 
-    for (_, pos_column, vel_column) in Query(world, (Const{Position}, Const{Velocity}))
+    for (_, pos_column, vel_column) in Query(world, (Const(Position), Const(Velocity)))
         @inbounds for i in eachindex(pos_column, vel_column)
             pos = pos_column[i]
             vel = vel_column[i]

--- a/docs/src/manual/queries.md
+++ b/docs/src/manual/queries.md
@@ -277,7 +277,7 @@ The query still matches entities by the component type, but the returned column
 rejects mutations:
 
 ```jldoctest; output = false
-for (entities, positions, velocities) in Query(world, (Const{Position}, Velocity))
+for (entities, positions, velocities) in Query(world, (Const(Position), Velocity))
     @inbounds for i in eachindex(entities)
         pos = positions[i]                 # allowed
         velocities[i] = Velocity(3, 4)     # allowed

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -18,15 +18,15 @@ end
 ```
 """
 struct Const{T}
-    function Const(::T) where T
+    function Const(::Type{T}) where T
         if !isbitstype(T)
             throw(ArgumentError("A component can be marked constant only if immutable."))
         end
-        return Const{T}
+        return new{T}()
     end
 end
 
-function _unwrap_const_type(::Type{Const{T}}) where {T}
+function _unwrap_const_type(::Const{T}) where {T}
     return T
 end
 
@@ -34,7 +34,7 @@ function _unwrap_const_type(::Type{T}) where {T}
     return T
 end
 
-function _is_const_type(::Type{Const{T}}) where {T}
+function _is_const_type(::Const{T}) where {T}
     return true
 end
 

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -1,6 +1,6 @@
 
 """
-    Const{T}
+    Const(T)
 
 Marks component `T` as read-only in a [`Query`](@ref) or [`Filter`](@ref).
 
@@ -10,14 +10,21 @@ but the returned component column is a read-only view.
 # Example
 
 ```julia
-for (_, positions, velocities) in Query(world, (Const{Position}, Velocity))
+for (_, positions, velocities) in Query(world, (Const(Position), Velocity))
     pos = positions[1]            # allowed
     velocities[1] = velocities[1] # allowed
     positions[1] = pos            # errors
 end
 ```
 """
-abstract type Const{T} end
+struct Const{T}
+    function Const(::T) where T
+        if !isbitstype(T)
+            throw(ArgumentError("A component can be marked constant only if immutable."))
+        end
+        return Const{T}
+    end
+end
 
 function _unwrap_const_type(::Type{Const{T}}) where {T}
     return T

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -26,7 +26,15 @@ struct Const{T}
     end
 end
 
-function _unwrap_const_type(::Const{T}) where {T}
+function _unwrap_ext_const_type(::Const{T}) where {T}
+    return T
+end
+
+function _unwrap_ext_const_type(::Type{T}) where {T}
+    return T
+end
+
+function _unwrap_const_type(::Type{Const{T}}) where {T}
     return T
 end
 
@@ -34,7 +42,7 @@ function _unwrap_const_type(::Type{T}) where {T}
     return T
 end
 
-function _is_const_type(::Const{T}) where {T}
+function _is_const_type(::Type{Const{T}}) where {T}
     return true
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -156,8 +156,8 @@ function _generate_component_switch(comp_idx_sym::Symbol, call_exprs::Vector{Exp
     return Expr(:block, exprs...)
 end
 
-@inline function _to_requested_types(::Type{TS})::Vector{DataType} where {TS<:Tuple}
-    return DataType[x <: Val ? _val_parameter(x) : x for x in fieldtypes(TS)]
+@inline function _to_requested_types(::Type{TS})::Vector{Any} where {TS<:Tuple}
+    return [x <: Val ? _val_parameter(x) : x for x in fieldtypes(TS)]
 end
 
 function _component_index(CS::Type{<:Tuple}, TargetType::Type)::Union{Int,Nothing}

--- a/src/util.jl
+++ b/src/util.jl
@@ -29,11 +29,11 @@ function _pair_first_type(::Type{<:Pair{T}}) where {T}
 end
 
 @inline function _to_types(::Type{TS})::Vector{DataType} where {TS<:Tuple}
-    return DataType[_unwrap_const_type(_val_parameter(x)) for x in fieldtypes(TS)]
+    return DataType[_unwrap_ext_const_type(_val_parameter(x)) for x in fieldtypes(TS)]
 end
 
 @inline function _to_types(::Type{Val{TS}})::Vector{DataType} where {TS<:Tuple}
-    return DataType[_unwrap_const_type(x <: Val ? _val_parameter(x) : x) for x in fieldtypes(TS)]
+    return DataType[_unwrap_ext_const_type(x <: Val ? _val_parameter(x) : x) for x in fieldtypes(TS)]
 end
 
 @inline function _to_types(::Type{Val{V}})::Vector{DataType} where {V<:Val}
@@ -41,7 +41,7 @@ end
 end
 
 @inline function _to_types(types::Tuple)::Vector{DataType}
-    return DataType[_unwrap_const_type(x) for x in types]
+    return DataType[_unwrap_ext_const_type(x) for x in types]
 end
 
 function _unwrap_relation_type(::Type{Relation{T}}) where {T}
@@ -156,8 +156,10 @@ function _generate_component_switch(comp_idx_sym::Symbol, call_exprs::Vector{Exp
     return Expr(:block, exprs...)
 end
 
-@inline function _to_requested_types(::Type{TS})::Vector{Any} where {TS<:Tuple}
-    return [x <: Val ? _val_parameter(x) : x for x in fieldtypes(TS)]
+@inline function _to_requested_types(::Type{TS})::Vector{DataType} where {TS<:Tuple}
+    return DataType[
+        (x <: Val ? _val_parameter(x) : x) isa Const ? Const{_unwrap_ext_const_type(x)} : x for x in fieldtypes(TS)
+    ]
 end
 
 function _component_index(CS::Type{<:Tuple}, TargetType::Type)::Union{Int,Nothing}

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -71,7 +71,7 @@ end
 
     new_entity!(world, (Position(1, 2), Velocity(3, 4), Altitude(5)))
 
-    _, positions, velocities = only(Query(world, (Const{Position}, Velocity)))
+    _, positions, velocities = only(Query(world, (Const(Position), Velocity)))
 
     @test size(positions) == (1,)
     @test axes(positions) == (Base.OneTo(1),)
@@ -95,19 +95,19 @@ end
     @test updated_positions[1] == Position(1, 2)
     @test updated_velocities[1] == Velocity(5, 6)
 
-    _, _, altitudes = only(Query(world, (Position,); optional=(Const{Altitude},)))
+    _, _, altitudes = only(Query(world, (Position,); optional=(Const(Altitude),)))
     @test altitudes isa ReadOnly
     @test altitudes[1] == Altitude(5)
     @test_throws Exception setindex!(altitudes, Altitude(10), 1)
 
-    filter = Filter(world, (Const{Position}, Velocity); optional=(Const{Altitude},))
+    filter = Filter(world, (Const(Position), Velocity); optional=(Const(Altitude),))
     @test string(filter) == "Filter((Const{Position}, Velocity); optional=(Const{Altitude}))"
     _, filter_positions, filter_velocities, filter_altitudes = only(Query(world, filter))
     @test filter_positions isa ReadOnly
     @test !(filter_velocities isa ReadOnly)
     @test filter_altitudes isa ReadOnly
 
-    registered_filter = Filter(world, (Const{Position},); register=true)
+    registered_filter = Filter(world, (Const(Position),); register=true)
     _, registered_positions = only(Query(world, registered_filter))
     @test registered_positions isa ReadOnly
     unregister!(world, registered_filter)
@@ -543,7 +543,7 @@ end
 
     new_entity!(world, (Position(1, 2), Velocity(3, 4), Altitude(5)))
 
-    query = Query(world, (Const{Position}, Velocity); optional=(Const{Altitude},))
+    query = Query(world, (Const(Position), Velocity); optional=(Const(Altitude),))
 
     @inferred Tuple{
         Entities,

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -81,6 +81,7 @@ end
     @test positions[1] == Position(1, 2)
     @test velocities[1] == Velocity(3, 4)
     @test_throws Exception setindex!(positions, Position(10, 20), 1)
+    @test_throws ArgumentError Const(MutableComponent)
 
     if !(typeof(positions) <: ReadOnly{<:Any,<:TestVectorView})
         xs = positions.x


### PR DESCRIPTION
it doesn't actually make sense for mutable ones