### PR TITLE
Add has_components/get_components/set_components! on queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@
 - `unregister!` and `register!` now require the world as an argument (#660).
 - API functions for `Query` and `Filter` now require the world as an argument (#662).
 - `length` for a filter has been renamed to `count_tables` (#662).
-- The `world` field of `EntityHandle` has been renamed to `source`, since a handle can now
-  be created from a `Query` as well.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@
 - Adds GPUVector{:CPU} and GPUStructArray{:CPU} to use a GPU storage on devices
   which do not have a GPU (#701).
 - Adds the `boxed` keyword argument to the world constructor, which cuts the compilation cost of Ark, at the price of some slowdown in performance.
+- Adds `get_components`, `set_components!` and `has_components` for a `Query`, to access the
+  components of a query for a single entity without iterating or closing the query.
+  `EntityHandle` now works with queries as well, i.e. `query[entity][Position]`.
 
 ### Breaking changes
 
 - `unregister!` and `register!` now require the world as an argument (#660).
 - API functions for `Query` and `Filter` now require the world as an argument (#662).
 - `length` for a filter has been renamed to `count_tables` (#662).
+- The `world` field of `EntityHandle` has been renamed to `source`, since a handle can now
+  be created from a `Query` as well.
 
 ### Performance
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -45,9 +45,9 @@ isless(::Entity,::Entity)
 [Components](@ref) contain the data associated with [Entities](@ref entities-api).
 
 ```@docs
-get_components
-has_components
-set_components!
+get_components(::World, ::Entity, ::Tuple)
+has_components(::World, ::Entity, ::Tuple)
+set_components!(::World, ::Entity, ::Tuple)
 add_components!
 remove_components!
 exchange_components!
@@ -77,6 +77,9 @@ certain set of [Components](@ref components-api).
 Query
 Query(::World,::Tuple;::Tuple,::Tuple,::Tuple,::Bool)
 Query(::World, ::Filter)
+get_components(::Query, ::Entity, ::Tuple)
+set_components!(::Query, ::Entity, ::Tuple)
+has_components(::Query, ::Entity, ::Tuple)
 close!(::Query)
 Filter
 Filter(::World,::Tuple;::Tuple,::Tuple,::Tuple,::Bool)

--- a/docs/src/manual/architecture.md
+++ b/docs/src/manual/architecture.md
@@ -57,7 +57,7 @@ In worlds with a large number of archetypes, query performance can be further im
 
 ## [World component access](@id component-access)
 
-To retrieve components for a specific entity outside query iteration ([get_components](@ref)),
+To retrieve components for a specific entity outside query iteration ([get_components](@ref get_components(::World, ::Entity, ::Tuple))),
 the World maintains a list indexed by entity ID (the entity index at the very left in the graph above).
 Each entry in this list points to the entity's archetype and the position within the archetype's table.
 

--- a/docs/src/manual/components.md
+++ b/docs/src/manual/components.md
@@ -19,7 +19,7 @@ by the optional argument `allow_mutable` of the [world constructor](@ref World(:
 
 Although the majority of the logic in an application that uses Ark will be performed in [Queries](@ref),
 it may be necessary to access components for a particular entity.
-One or more components of an entity can be accessed via [get_components](@ref):
+One or more components of an entity can be accessed via [get_components](@ref get_components(::World, ::Entity, ::Tuple)):
 
 ```@meta
 DocTestSetup = quote
@@ -65,7 +65,7 @@ has_pos_vel = (Position, Velocity) in we
 true
 ```
 
-Similarly, the components of an entity can be overwritten by new values via [set_components!](@ref) or by indexing:
+Similarly, the components of an entity can be overwritten by new values via [set_components!](@ref set_components!(::World, ::Entity, ::Tuple)) or by indexing:
 
 ```jldoctest; output = false
 set_components!(world, entity, (Position(0, 0), Velocity(1,1)))
@@ -136,7 +136,7 @@ For these columns, Ark offers storage types for both CPU anf GPU computing by de
   - Not allowed for mutable components.
   - Not allowed for components without fields, like labels and primitives.
   - ≈10-20% runtime overhead for component operations and entity creation.
-  - Slower component access with [get_components](@ref) and [set_components!](@ref).
+  - Slower component access with [get_components](@ref get_components(::World, ::Entity, ::Tuple)) and [set_components!](@ref set_components!(::World, ::Entity, ::Tuple)).
 
 ### GPU Storages
 

--- a/docs/src/manual/queries.md
+++ b/docs/src/manual/queries.md
@@ -270,6 +270,35 @@ The world is automatically unlocked when query iteration finishes.
 When breaking out of a query loop, however, it must be unlocked by calling
 [close!](@ref close!(::Query)) on the query.
 
+## Single entity access
+
+Components of a single [Entity](@ref) can also be accessed through a query, without
+iterating it. Only the components of the query are accessible, optional and
+[`Const`](@ref) ones included:
+
+```jldoctest; output = false
+entity = new_entity!(world, (Position(0, 0), Velocity(1, 1)))
+query = Query(world, (Position, Velocity))
+
+pos, vel = get_components(query, entity, (Position, Velocity))
+set_components!(query, entity, (Position(pos.x + vel.dx, pos.y + vel.dy),))
+has_both = has_components(query, entity, (Position, Velocity))
+
+# the same, using an entity handle
+qe = query[entity]
+pos, vel = qe[(Position, Velocity)]
+qe[Position] = Position(pos.x + vel.dx, pos.y + vel.dy)
+
+close!(query)
+
+# output
+
+```
+
+These operations neither iterate nor [close!](@ref close!(::Query)) the query, so the query
+can still be iterated afterwards. As during iteration, the entity must have the components
+which are accessed, and [`Const`](@ref) components can't be set.
+
 ## `Const` components
 
 Components wrapped in [`Const`](@ref) are read-only during query iteration.

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -1,11 +1,16 @@
 
 """
-    EntityHandle{W<:World}
+    EntityHandle{S<:Union{World,Query}}
 
-A handle to an [`Entity`](@ref) within a specific [`World`](@ref),
+A handle to an [`Entity`](@ref) within a specific [`World`](@ref) or [`Query`](@ref),
 allowing for dict-like component and relationship access.
 
-Created by indexing a world with an entity i.e. `we = world[entity]`.
+Created by indexing a world or a query with an entity i.e. `we = world[entity]`
+or `qe = query[entity]`.
+
+A handle created from a query gives access only to the components of the query and
+supports component access alone, i.e. no relationships and no structural changes.
+Creating and using it neither iterates nor [closes](@ref close!(::Query)) the query.
 
 # Examples
 
@@ -28,9 +33,15 @@ has_pos_vel = (Position, Velocity) in we
 we.rel[ChildOf] = parent
 parent = we.rel[ChildOf]
 
+# Components of a query
+query = Query(world, (Position, Velocity))
+qe = query[entity]
+pos, vel = qe[(Position, Velocity)]
+qe[Position] = Position(0, 0)
+close!(query)
+
 # output
 
-Entity(2, 0)
 ```
 
 !!! note
@@ -39,8 +50,8 @@ Entity(2, 0)
     directly the entities instead. Handles are provided only to allow to use a more appealing syntax for access and
     modification of components and relationships.
 """
-struct EntityHandle{W<:World}
-    world::W
+struct EntityHandle{S<:Union{World,Query}}
+    source::S
     entity::Entity
 end
 
@@ -51,36 +62,38 @@ end
 
 @inline Base.getindex(world::World, entity::Entity) = EntityHandle(world, entity)
 
+@inline Base.getindex(query::Query, entity::Entity) = EntityHandle(query, entity)
+
 @inline Base.@constprop :aggressive function Base.getindex(entityhandle::EntityHandle, ::Type{T}) where {T}
-    return get_components(entityhandle.world, entityhandle.entity, (T,))[1]
+    return get_components(entityhandle.source, entityhandle.entity, (T,))[1]
 end
 
 @inline Base.@constprop :aggressive function Base.getindex(entityhandle::EntityHandle, comps::Tuple)
-    return get_components(entityhandle.world, entityhandle.entity, comps)
+    return get_components(entityhandle.source, entityhandle.entity, comps)
 end
 
 @inline Base.@constprop :aggressive function Base.setindex!(entityhandle::EntityHandle, value, ::Type{T}) where {T}
-    set_components!(entityhandle.world, entityhandle.entity, (value,))[1]
+    set_components!(entityhandle.source, entityhandle.entity, (value,))[1]
 end
 
 @inline Base.@constprop :aggressive function Base.setindex!(entityhandle::EntityHandle, values::Tuple, comps::Tuple)
-    set_components!(entityhandle.world, entityhandle.entity, values)
+    set_components!(entityhandle.source, entityhandle.entity, values)
 end
 
 @inline Base.@constprop :aggressive function Base.in(::Type{T}, entityhandle::EntityHandle) where {T}
-    return has_components(entityhandle.world, entityhandle.entity, (T,))
+    return has_components(entityhandle.source, entityhandle.entity, (T,))
 end
 
 @inline Base.@constprop :aggressive function Base.in(comps::Tuple, entityhandle::EntityHandle)
-    return has_components(entityhandle.world, entityhandle.entity, comps)
+    return has_components(entityhandle.source, entityhandle.entity, comps)
 end
 
 @inline Base.@constprop :aggressive function _unchecked_getindex(entityhandle::EntityHandle, ::Type{T}) where {T}
-    return get_components(entityhandle.world, entityhandle.entity, (T,); _unchecked=true)[1]
+    return get_components(entityhandle.source, entityhandle.entity, (T,); _unchecked=true)[1]
 end
 
 @inline Base.@constprop :aggressive function _unchecked_getindex(entityhandle::EntityHandle, comps::Tuple)
-    return get_components(entityhandle.world, entityhandle.entity, comps; _unchecked=true)
+    return get_components(entityhandle.source, entityhandle.entity, comps; _unchecked=true)
 end
 
 @inline Base.@constprop :aggressive function _unchecked_setindex!(
@@ -88,7 +101,7 @@ end
     value,
     ::Type{T},
 ) where {T}
-    set_components!(entityhandle.world, entityhandle.entity, (value,); _unchecked=true)
+    set_components!(entityhandle.source, entityhandle.entity, (value,); _unchecked=true)
 end
 
 @inline Base.@constprop :aggressive function _unchecked_setindex!(
@@ -96,40 +109,44 @@ end
     values::Tuple,
     comps::Tuple,
 )
-    set_components!(entityhandle.world, entityhandle.entity, values; _unchecked=true)
+    set_components!(entityhandle.source, entityhandle.entity, values; _unchecked=true)
 end
 
 @inline Base.@constprop :aggressive function _unchecked_in(::Type{T}, entityhandle::EntityHandle) where {T}
-    return has_components(entityhandle.world, entityhandle.entity, (T,); _unchecked=true)
+    return has_components(entityhandle.source, entityhandle.entity, (T,); _unchecked=true)
 end
 
 @inline Base.@constprop :aggressive function _unchecked_in(comps::Tuple, entityhandle::EntityHandle)
-    return has_components(entityhandle.world, entityhandle.entity, comps; _unchecked=true)
+    return has_components(entityhandle.source, entityhandle.entity, comps; _unchecked=true)
 end
 
 @inline Base.@constprop :aggressive function add_components!(
-    entityhandle::EntityHandle,
+    entityhandle::EntityHandle{<:World},
     values::Tuple;
     _unchecked::Bool=false,
 )
-    world = entityhandle.world
+    world = entityhandle.source
     entity = entityhandle.entity
     return add_components!(world, entity, values; _unchecked)
 end
 
 @inline Base.@constprop :aggressive function remove_components!(
-    entityhandle::EntityHandle,
+    entityhandle::EntityHandle{<:World},
     comp_types::Tuple;
     _unchecked::Bool=false,
 )
-    world = entityhandle.world
+    world = entityhandle.source
     entity = entityhandle.entity
     return remove_components!(world, entity, comp_types; _unchecked)
 end
 
 Base.@constprop :aggressive function Base.getproperty(entityhandle::EntityHandle, name::Symbol)
     if name === :rel
-        return _EntityHandleRel(getfield(entityhandle, :world), getfield(entityhandle, :entity))
+        source = getfield(entityhandle, :source)
+        if !(source isa World)
+            throw(ArgumentError("relations can be accessed only through a world handle"))
+        end
+        return _EntityHandleRel(source, getfield(entityhandle, :entity))
     end
     return getfield(entityhandle, name)
 end

--- a/src/query.jl
+++ b/src/query.jl
@@ -587,7 +587,7 @@ end
     if length(types) == 0
         return :(())
     end
- 
+
     query_types = _query_component_types(QS)
     indices = Int[_query_component_index(query_types, T) for T in types]
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -477,11 +477,11 @@ end
 end
 
 @generated function _get_components(
-    q::Query{QS},
+    q::Query{QS,CT,OF},
     entity::Entity,
     ::TS,
     ::Val{Unchecked},
-) where {QS<:Tuple,TS<:Tuple,Unchecked}
+) where {QS<:Tuple,CT<:Tuple,OF,TS<:Tuple,Unchecked}
     types = _to_types(TS)
     _check_no_duplicates(types)
 
@@ -513,7 +513,7 @@ end
         val_sym = Symbol("v", i)
 
         push!(exprs, :($cols_sym = q._storages[$(indices[i])]))
-        if !Unchecked
+        if !Unchecked && _get_bit(OF, indices[i])
             push!(exprs, :(_check_query_component($cols_sym, idx, $(types[i]))))
         end
         push!(exprs, :($val_sym = _get_component($cols_sym, idx.table, idx.row)))
@@ -530,11 +530,11 @@ end
 end
 
 @generated function _has_components(
-    q::Query{QS},
+    q::Query{QS,CT,OF},
     entity::Entity,
     ::TS,
     ::Val{Unchecked},
-) where {QS<:Tuple,TS<:Tuple,Unchecked}
+) where {QS<:Tuple,CT<:Tuple,OF,TS<:Tuple,Unchecked}
     types = _to_types(TS)
     _check_no_duplicates(types)
 
@@ -557,8 +557,9 @@ end
 
     push!(exprs, :(@inbounds idx = q._world_state._entities[entity._id]))
 
-    checks = Expr[:(_has_query_component(q._storages[$index], idx)) for index in indices]
-    check_expr = foldr((a, b) -> Expr(:&&, a, b), checks)
+    checked_indices = Unchecked ? indices : Int[index for index in indices if _get_bit(OF, index)]
+    checks = Expr[:(_has_query_component(q._storages[$index], idx)) for index in checked_indices]
+    check_expr = isempty(checks) ? :(true) : foldr((a, b) -> Expr(:&&, a, b), checks)
 
     if !Unchecked
         push!(exprs, Expr(:return, :(_matches_query(q, idx) && $check_expr)))
@@ -616,7 +617,7 @@ end
         cols_sym = Symbol("cols", i)
 
         push!(exprs, :($cols_sym = q._storages[$(indices[i])]))
-        if !Unchecked
+        if !Unchecked && _get_bit(OF, indices[i])
             push!(exprs, :(_check_query_component($cols_sym, idx, $(types[i]))))
         end
         push!(exprs, :(_set_component!($cols_sym, idx.table, idx.row, values[$i])))

--- a/src/query.jl
+++ b/src/query.jl
@@ -354,7 +354,7 @@ close!(query)
     comp_types::Tuple;
     _unchecked::Bool=false,
 )
-    return @inline _query_get_components(query, entity, _valtuple(comp_types), Val(_unchecked))
+    return @inline _get_components(query, entity, _valtuple(comp_types), Val(_unchecked))
 end
 
 """
@@ -386,7 +386,7 @@ close!(query)
     values::Tuple;
     _unchecked::Bool=false,
 )
-    return @inline _query_set_components!(
+    return @inline _set_components!(
         query,
         entity,
         Val{typeof(values)}(),
@@ -422,7 +422,7 @@ close!(query)
     comp_types::Tuple;
     _unchecked::Bool=false,
 )
-    return @inline _query_has_components(query, entity, _valtuple(comp_types), Val(_unchecked))
+    return @inline _has_components(query, entity, _valtuple(comp_types), Val(_unchecked))
 end
 
 _query_component_types(::Type{QS}) where {QS<:Tuple} =
@@ -457,7 +457,7 @@ end
     return nothing
 end
 
-@generated function _query_get_components(
+@generated function _get_components(
     q::Query{QS},
     entity::Entity,
     ::TS,
@@ -506,7 +506,7 @@ end
     end
 end
 
-@generated function _query_has_components(
+@generated function _has_components(
     q::Query{QS},
     entity::Entity,
     ::TS,
@@ -545,7 +545,7 @@ end
     end
 end
 
-@generated function _query_set_components!(
+@generated function _set_components!(
     q::Query{QS,CT,OF,RO},
     entity::Entity,
     ::Val{TS},
@@ -558,7 +558,7 @@ end
     if length(types) == 0
         return :()
     end
-
+ 
     query_types = _query_component_types(QS)
     indices = Int[_query_component_index(query_types, T) for T in types]
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -333,7 +333,8 @@ Get the given components for an [Entity](@ref) through a [Query](@ref).
 Components are returned as a tuple.
 
 Only components which are part of the query can be accessed, optional and
-[Const](@ref) ones included. The entity must have all the requested components.
+[Const](@ref) ones included. The entity must match the query and have all the
+requested components.
 
 Does not iterate or [close!](@ref close!(::Query)) the query.
 
@@ -365,7 +366,7 @@ Types are inferred from the values.
 
 Only components which are part of the query can be set, optional ones included.
 Components marked as [Const](@ref) in the query are read-only and can't be set.
-The entity must have all the given components.
+The entity must match the query and have all the given components.
 
 Does not iterate or [close!](@ref close!(::Query)) the query.
 
@@ -401,7 +402,8 @@ end
 Returns whether an [Entity](@ref) has all the given components.
 
 Only components which are part of the query can be checked, optional and
-[Const](@ref) ones included.
+[Const](@ref) ones included. An entity that does not match the query returns
+`false`.
 
 Does not iterate or [close!](@ref close!(::Query)) the query.
 
@@ -457,6 +459,23 @@ end
     return nothing
 end
 
+@inline function _matches_query(q::Query, idx::_EntityIndex)
+    world_state = q._world_state
+    @inbounds table = world_state._tables[idx.table]
+    @inbounds archetype = world_state._archetypes_hot[table.archetype]
+    return _matches(q._filter, archetype) &&
+           _matches(world_state._relations, table, q._filter.relations)
+end
+
+@noinline function _throw_entity_not_in_query()
+    throw(ArgumentError("entity does not match query"))
+end
+
+@inline function _check_query_match(q::Query, idx::_EntityIndex)
+    _matches_query(q, idx) || _throw_entity_not_in_query()
+    return nothing
+end
+
 @generated function _get_components(
     q::Query{QS},
     entity::Entity,
@@ -484,6 +503,10 @@ end
     end
 
     push!(exprs, :(@inbounds idx = q._world_state._entities[entity._id]))
+
+    if !Unchecked
+        push!(exprs, :(_check_query_match(q, idx)))
+    end
 
     for i in eachindex(types)
         cols_sym = Symbol("cols", i)
@@ -536,7 +559,12 @@ end
 
     checks = Expr[:(_has_query_component(q._storages[$index], idx)) for index in indices]
     check_expr = foldr((a, b) -> Expr(:&&, a, b), checks)
-    push!(exprs, Expr(:return, check_expr))
+
+    if !Unchecked
+        push!(exprs, Expr(:return, :(_matches_query(q, idx) && $check_expr)))
+    else
+        push!(exprs, Expr(:return, check_expr))
+    end
 
     return quote
         @inbounds begin
@@ -579,6 +607,10 @@ end
     end
 
     push!(exprs, :(@inbounds idx = q._world_state._entities[entity._id]))
+
+    if !Unchecked
+        push!(exprs, :(_check_query_match(q, idx)))
+    end
 
     for i in eachindex(types)
         cols_sym = Symbol("cols", i)

--- a/src/query.jl
+++ b/src/query.jl
@@ -534,7 +534,7 @@ end
 
     push!(exprs, :(@inbounds idx = q._world_state._entities[entity._id]))
 
-    checks = Any[:(_has_query_component(q._storages[$index], idx)) for index in indices]
+    checks = Expr[:(_has_query_component(q._storages[$index], idx)) for index in indices]
     check_expr = foldr((a, b) -> Expr(:&&, a, b), checks)
     push!(exprs, Expr(:return, check_expr))
 
@@ -556,7 +556,7 @@ end
     _check_no_duplicates(types)
 
     if length(types) == 0
-        return :(values)
+        return :()
     end
 
     query_types = _query_component_types(QS)

--- a/src/query.jl
+++ b/src/query.jl
@@ -556,7 +556,7 @@ end
     _check_no_duplicates(types)
 
     if length(types) == 0
-        return :()
+        return :(())
     end
  
     query_types = _query_component_types(QS)

--- a/src/query.jl
+++ b/src/query.jl
@@ -327,6 +327,279 @@ function count_entities(world::World, q::Query)
 end
 
 """
+    get_components(query::Query, entity::Entity, comp_types::Tuple)
+
+Get the given components for an [Entity](@ref) through a [Query](@ref).
+Components are returned as a tuple.
+
+Only components which are part of the query can be accessed, optional and
+[Const](@ref) ones included. The entity must have all the requested components.
+
+Does not iterate or [close!](@ref close!(::Query)) the query.
+
+# Example
+
+```jldoctest; setup = :(using Ark; include(string(dirname(pathof(Ark)), "/docs.jl"))), output = false
+query = Query(world, (Position, Velocity))
+pos, vel = get_components(query, entity, (Position, Velocity))
+close!(query)
+
+# output
+
+```
+"""
+@inline Base.@constprop :aggressive function get_components(
+    query::Query,
+    entity::Entity,
+    comp_types::Tuple;
+    _unchecked::Bool=false,
+)
+    return @inline _query_get_components(query, entity, _valtuple(comp_types), Val(_unchecked))
+end
+
+"""
+    set_components!(query::Query, entity::Entity, values::Tuple)
+
+Sets the given component values for an [Entity](@ref) through a [Query](@ref).
+Types are inferred from the values.
+
+Only components which are part of the query can be set, optional ones included.
+Components marked as [Const](@ref) in the query are read-only and can't be set.
+The entity must have all the given components.
+
+Does not iterate or [close!](@ref close!(::Query)) the query.
+
+# Example
+
+```jldoctest; setup = :(using Ark; include(string(dirname(pathof(Ark)), "/docs.jl"))), output = false
+query = Query(world, (Position, Velocity))
+set_components!(query, entity, (Position(0, 0), Velocity(1, 1)))
+close!(query)
+
+# output
+
+```
+"""
+@inline Base.@constprop :aggressive function set_components!(
+    query::Query,
+    entity::Entity,
+    values::Tuple;
+    _unchecked::Bool=false,
+)
+    return @inline _query_set_components!(
+        query,
+        entity,
+        Val{typeof(values)}(),
+        values,
+        Val(_unchecked),
+    )
+end
+
+"""
+    has_components(query::Query, entity::Entity, comp_types::Tuple)::Bool
+
+Returns whether an [Entity](@ref) has all the given components.
+
+Only components which are part of the query can be checked, optional and
+[Const](@ref) ones included.
+
+Does not iterate or [close!](@ref close!(::Query)) the query.
+
+# Example
+
+```jldoctest; setup = :(using Ark; include(string(dirname(pathof(Ark)), "/docs.jl"))), output = false
+query = Query(world, (Position, Velocity))
+has = has_components(query, entity, (Position, Velocity))
+close!(query)
+
+# output
+
+```
+"""
+@inline Base.@constprop :aggressive function has_components(
+    query::Query,
+    entity::Entity,
+    comp_types::Tuple;
+    _unchecked::Bool=false,
+)
+    return @inline _query_has_components(query, entity, _valtuple(comp_types), Val(_unchecked))
+end
+
+_query_component_types(::Type{QS}) where {QS<:Tuple} =
+    DataType[_component_type(S) for S in fieldtypes(QS)]
+
+function _query_component_index(query_types::Vector{DataType}, T::DataType)
+    index = findfirst(==(T), query_types)
+    if index === nothing
+        available = join(map(_format_type, query_types), ", ")
+        throw(ArgumentError(lazy"component $(_format_type(T)) is not part of the query on ($available)"))
+    end
+    return index
+end
+
+@noinline function _throw_missing_query_component(::Type{T}) where {T}
+    throw(ArgumentError(lazy"entity has no $T component"))
+end
+
+@inline function _has_query_component(cols::Vector{A}, idx::_EntityIndex) where {A<:AbstractArray}
+    table = Int(idx.table)
+    return table <= length(cols) && length(@inbounds cols[table]) >= idx.row
+end
+
+@inline function _check_query_component(
+    cols::Vector{A},
+    idx::_EntityIndex,
+    ::Type{T},
+) where {A<:AbstractArray,T}
+    if !_has_query_component(cols, idx)
+        _throw_missing_query_component(T)
+    end
+    return nothing
+end
+
+@generated function _query_get_components(
+    q::Query{QS},
+    entity::Entity,
+    ::TS,
+    ::Val{Unchecked},
+) where {QS<:Tuple,TS<:Tuple,Unchecked}
+    types = _to_types(TS)
+    _check_no_duplicates(types)
+
+    if length(types) == 0
+        return :(())
+    end
+
+    query_types = _query_component_types(QS)
+    indices = Int[_query_component_index(query_types, T) for T in types]
+
+    exprs = Expr[]
+
+    if !Unchecked
+        push!(exprs, :(
+            if !is_alive(q._world_state, entity)
+                throw(ArgumentError("can't get components of a dead entity"))
+            end
+        ))
+    end
+
+    push!(exprs, :(@inbounds idx = q._world_state._entities[entity._id]))
+
+    for i in eachindex(types)
+        cols_sym = Symbol("cols", i)
+        val_sym = Symbol("v", i)
+
+        push!(exprs, :($cols_sym = q._storages[$(indices[i])]))
+        if !Unchecked
+            push!(exprs, :(_check_query_component($cols_sym, idx, $(types[i]))))
+        end
+        push!(exprs, :($val_sym = _get_component($cols_sym, idx.table, idx.row)))
+    end
+
+    vals = Symbol[Symbol("v", i) for i in eachindex(types)]
+    push!(exprs, Expr(:return, Expr(:tuple, vals...)))
+
+    return quote
+        @inbounds begin
+            $(Expr(:block, exprs...))
+        end
+    end
+end
+
+@generated function _query_has_components(
+    q::Query{QS},
+    entity::Entity,
+    ::TS,
+    ::Val{Unchecked},
+) where {QS<:Tuple,TS<:Tuple,Unchecked}
+    types = _to_types(TS)
+    _check_no_duplicates(types)
+
+    if length(types) == 0
+        return :(true)
+    end
+
+    query_types = _query_component_types(QS)
+    indices = Int[_query_component_index(query_types, T) for T in types]
+
+    exprs = Expr[]
+
+    if !Unchecked
+        push!(exprs, :(
+            if !is_alive(q._world_state, entity)
+                throw(ArgumentError("can't check components of a dead entity"))
+            end
+        ))
+    end
+
+    push!(exprs, :(@inbounds idx = q._world_state._entities[entity._id]))
+
+    checks = Any[:(_has_query_component(q._storages[$index], idx)) for index in indices]
+    check_expr = foldr((a, b) -> Expr(:&&, a, b), checks)
+    push!(exprs, Expr(:return, check_expr))
+
+    return quote
+        @inbounds begin
+            $(Expr(:block, exprs...))
+        end
+    end
+end
+
+@generated function _query_set_components!(
+    q::Query{QS,CT,OF,RO},
+    entity::Entity,
+    ::Val{TS},
+    values::Tuple,
+    ::Val{Unchecked},
+) where {QS<:Tuple,CT<:Tuple,OF,RO,TS<:Tuple,Unchecked}
+    types = _to_types(fieldtypes(TS))
+    _check_no_duplicates(types)
+
+    if length(types) == 0
+        return :(values)
+    end
+
+    query_types = _query_component_types(QS)
+    indices = Int[_query_component_index(query_types, T) for T in types]
+
+    for i in eachindex(types)
+        if _get_bit(RO, indices[i])
+            throw(ArgumentError(lazy"component $(_format_type(types[i])) is read-only in the query"))
+        end
+    end
+
+    exprs = Expr[]
+
+    if !Unchecked
+        push!(exprs, :(
+            if !is_alive(q._world_state, entity)
+                throw(ArgumentError("can't set components of a dead entity"))
+            end
+        ))
+    end
+
+    push!(exprs, :(@inbounds idx = q._world_state._entities[entity._id]))
+
+    for i in eachindex(types)
+        cols_sym = Symbol("cols", i)
+
+        push!(exprs, :($cols_sym = q._storages[$(indices[i])]))
+        if !Unchecked
+            push!(exprs, :(_check_query_component($cols_sym, idx, $(types[i]))))
+        end
+        push!(exprs, :(_set_component!($cols_sym, idx.table, idx.row, values[$i])))
+    end
+
+    push!(exprs, Expr(:return, :values))
+
+    return quote
+        @inbounds begin
+            $(Expr(:block, exprs...))
+        end
+    end
+end
+
+"""
     close!(q::Query)
 
 Closes the query and unlocks the world.

--- a/test/test_indexing_api.jl
+++ b/test/test_indexing_api.jl
@@ -125,3 +125,69 @@
         @test Ark._unchecked_in(1, [1]) == true
     end
 end
+
+@testset "Query indexing API" begin
+    world = TestWorld(Position, Velocity, Altitude, Health)
+
+    e1 = new_entity!(world, (Position(1.0, 2.0), Velocity(0.1, 0.2)))
+    e2 = new_entity!(world, (Position(10.0, 20.0), Velocity(1.0, 2.0), Health(5.0)))
+
+    query = Query(world, (Position, Velocity))
+    qe1 = query[e1]
+    qe2 = query[e2]
+
+    @testset "Components" begin
+        # getting
+        @test qe1[Position] == Position(1.0, 2.0)
+        @test qe1[(Position, Velocity)] == (Position(1.0, 2.0), Velocity(0.1, 0.2))
+        @test qe2[(Velocity, Position)] == (Velocity(1.0, 2.0), Position(10.0, 20.0))
+
+        # setting
+        qe1[Position] = Position(3.0, 4.0)
+        @test qe1[Position] == Position(3.0, 4.0)
+
+        qe1[(Position, Velocity)] = (Position(5.0, 6.0), Velocity(0.5, 0.6))
+        @test qe1[Position] == Position(5.0, 6.0)
+        @test qe1[Velocity] == Velocity(0.5, 0.6)
+        @test get_components(world, e1, (Position, Velocity)) == (Position(5.0, 6.0), Velocity(0.5, 0.6))
+
+        # has components
+        @test Position in qe1
+        @test (Position, Velocity) in qe1
+
+        # components outside of the query are not accessible
+        @test_throws(
+            "ArgumentError: component Health is not part of the query (Position, Velocity)",
+            qe2[Health]
+        )
+
+        # relations and structural changes are not available through a query handle
+        @test_throws("ArgumentError: relations can be accessed only through a world handle", qe1.rel)
+        @test_throws MethodError add_components!(qe1, (Health(1.0),))
+        @test_throws MethodError remove_components!(qe1, (Velocity,))
+    end
+
+    @testset "Unchecked" begin
+        @unchecked begin
+            @test qe1[Position] == Position(5.0, 6.0)
+            @test Base.getindex(qe1, Position) == Position(5.0, 6.0)
+            qe1[Position] = Position(7.0, 8.0)
+            @test qe1[Position] == Position(7.0, 8.0)
+
+            qe1[(Position, Velocity)] = (Position(9.0, 10.0), Velocity(1.1, 1.2))
+            @test qe1[(Position, Velocity)] == (Position(9.0, 10.0), Velocity(1.1, 1.2))
+        end
+    end
+
+    @testset "Query is not consumed" begin
+        @test query._q_lock.closed == false
+        @test is_locked(world) == true
+
+        count = 0
+        for (entities, positions, velocities) in query
+            count += length(entities)
+        end
+        @test count == 2
+        @test is_locked(world) == false
+    end
+end

--- a/test/test_indexing_api.jl
+++ b/test/test_indexing_api.jl
@@ -157,7 +157,7 @@ end
 
         # components outside of the query are not accessible
         @test_throws(
-            "ArgumentError: component Health is not part of the query (Position, Velocity)",
+            "ArgumentError: component Health is not part of the query on (Position, Velocity)",
             qe2[Health]
         )
 

--- a/test/test_indexing_api.jl
+++ b/test/test_indexing_api.jl
@@ -137,12 +137,10 @@ end
     qe2 = query[e2]
 
     @testset "Components" begin
-        # getting
         @test qe1[Position] == Position(1.0, 2.0)
         @test qe1[(Position, Velocity)] == (Position(1.0, 2.0), Velocity(0.1, 0.2))
         @test qe2[(Velocity, Position)] == (Velocity(1.0, 2.0), Position(10.0, 20.0))
 
-        # setting
         qe1[Position] = Position(3.0, 4.0)
         @test qe1[Position] == Position(3.0, 4.0)
 
@@ -151,17 +149,14 @@ end
         @test qe1[Velocity] == Velocity(0.5, 0.6)
         @test get_components(world, e1, (Position, Velocity)) == (Position(5.0, 6.0), Velocity(0.5, 0.6))
 
-        # has components
         @test Position in qe1
         @test (Position, Velocity) in qe1
 
-        # components outside of the query are not accessible
         @test_throws(
             "ArgumentError: component Health is not part of the query on (Position, Velocity)",
             qe2[Health]
         )
 
-        # relations and structural changes are not available through a query handle
         @test_throws("ArgumentError: relations can be accessed only through a world handle", qe1.rel)
         @test_throws MethodError add_components!(qe1, (Health(1.0),))
         @test_throws MethodError remove_components!(qe1, (Velocity,))

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -685,3 +685,181 @@ end
         @test allocs <= 48
     end
 end
+
+@testset "Query entity component access" begin
+    world = TestWorld(Dummy, Position, Velocity, Altitude, Health)
+
+    e1 = new_entity!(world, (Position(1, 2), Velocity(3, 4)))
+    e2 = new_entity!(world, (Position(5, 6), Velocity(7, 8), Health(10)))
+    e3 = new_entity!(world, (Health(1),))
+
+    query = Query(world, (Position, Velocity))
+
+    # getting
+    @test get_components(query, e1, (Position, Velocity)) == (Position(1, 2), Velocity(3, 4))
+    @test get_components(query, e1, (Velocity, Position)) == (Velocity(3, 4), Position(1, 2))
+    @test get_components(query, e1, (Position,)) == (Position(1, 2),)
+    @test get_components(query, e2, (Position, Velocity)) == (Position(5, 6), Velocity(7, 8))
+    @test get_components(query, e1, ()) == ()
+
+    # checking
+    @test has_components(query, e1, (Position, Velocity)) == true
+    @test has_components(query, e3, (Position,)) == false
+    @test has_components(query, e3, (Position, Velocity)) == false
+    @test has_components(query, e1, ()) == true
+
+    # setting
+    @test set_components!(query, e1, (Position(0, 0),)) == (Position(0, 0),)
+    @test get_components(query, e1, (Position,)) == (Position(0, 0),)
+    set_components!(query, e1, (Velocity(1, 1), Position(2, 2)))
+    @test get_components(world, e1, (Position, Velocity)) == (Position(2, 2), Velocity(1, 1))
+    @test set_components!(query, e1, ()) == ()
+
+    # inference (the component types are constant-folded)
+    get_pos_vel(q, e) = get_components(q, e, (Position, Velocity))
+    set_pos(q, e) = set_components!(q, e, (Position(2, 2),))
+    has_pos_vel(q, e) = has_components(q, e, (Position, Velocity))
+    @inferred get_pos_vel(query, e1)
+    @inferred set_pos(query, e1)
+    @inferred has_pos_vel(query, e1)
+
+    # the operations above neither iterate nor close the query
+    @test query._q_lock.closed == false
+    @test is_locked(world) == true
+    @test count_tables(world, query) == 2
+    @test count_entities(world, query) == 2
+
+    count = 0
+    for (entities, positions, velocities) in query
+        count += length(entities)
+    end
+    @test count == 2
+    @test query._q_lock.closed == true
+    @test is_locked(world) == false
+end
+
+@testset "Query entity component access with Const" begin
+    world = TestWorld(Position, Velocity, Altitude)
+
+    e1 = new_entity!(world, (Position(1, 2), Velocity(3, 4), Altitude(5)))
+
+    query = Query(world, (Const(Position), Velocity); optional=(Const(Altitude),))
+
+    @test get_components(query, e1, (Position,)) == (Position(1, 2),)
+    @test get_components(query, e1, (Const(Position), Altitude)) == (Position(1, 2), Altitude(5))
+    @test set_components!(query, e1, (Velocity(0, 0),)) == (Velocity(0, 0),)
+
+    @test_throws(
+        "ArgumentError: component Position is read-only in the query",
+        set_components!(query, e1, (Position(0, 0),))
+    )
+    @test_throws(
+        "ArgumentError: component Altitude is read-only in the query",
+        set_components!(query, e1, (Altitude(0),))
+    )
+    close!(query)
+end
+
+@testset "Query entity component access with optional" begin
+    world = TestWorld(Position, Velocity, Health)
+
+    e1 = new_entity!(world, (Position(1, 2), Velocity(3, 4), Health(10)))
+    e2 = new_entity!(world, (Position(5, 6), Velocity(7, 8)))
+
+    query = Query(world, (Position,); optional=(Health,))
+
+    @test get_components(query, e1, (Position, Health)) == (Position(1, 2), Health(10))
+    set_components!(query, e1, (Health(20),))
+    @test get_components(query, e1, (Health,)) == (Health(20),)
+
+    @test has_components(query, e1, (Health,)) == true
+    @test has_components(query, e2, (Health,)) == false
+
+    @test_throws("ArgumentError: entity has no Health component", get_components(query, e2, (Health,)))
+    @test_throws("ArgumentError: entity has no Health component", set_components!(query, e2, (Health(1),)))
+    close!(query)
+end
+
+@testset "Query entity component access errors" begin
+    world = TestWorld(Dummy, Position, Velocity, Health)
+
+    e1 = new_entity!(world, (Position(1, 2), Velocity(3, 4)))
+    e2 = new_entity!(world, (Health(1),))
+    dead = new_entity!(world, (Position(0, 0), Velocity(0, 0)))
+    remove_entity!(world, dead)
+
+    query = Query(world, (Position, Velocity))
+
+    @test_throws(
+        "ArgumentError: component Health is not part of the query (Position, Velocity)",
+        get_components(query, e1, (Health,))
+    )
+    @test_throws(
+        "ArgumentError: component Health is not part of the query (Position, Velocity)",
+        set_components!(query, e1, (Health(1),))
+    )
+    @test_throws("ArgumentError: entity has no Position component", get_components(query, e2, (Position,)))
+    @test_throws("ArgumentError: entity has no Position component", set_components!(query, e2, (Position(1, 1),)))
+    @test_throws(
+        "ArgumentError: component Health is not part of the query (Position, Velocity)",
+        has_components(query, e1, (Health,))
+    )
+    @test_throws("ArgumentError: can't get components of a dead entity", get_components(query, dead, (Position,)))
+    @test_throws(
+        "ArgumentError: can't check components of a dead entity",
+        has_components(query, dead, (Position,))
+    )
+    @test_throws(
+        "ArgumentError: can't set components of a dead entity",
+        set_components!(query, dead, (Position(1, 1),))
+    )
+    @test_throws(
+        "ArgumentError: duplicate component types: Position",
+        get_components(query, e1, (Position, Position))
+    )
+    @test_throws(
+        "ArgumentError: duplicate component types: Position",
+        set_components!(query, e1, (Position(1, 1), Position(2, 2)))
+    )
+
+    # the query is still usable
+    @test get_components(query, e1, (Position, Velocity)) == (Position(1, 2), Velocity(3, 4))
+    @test count_entities(world, query) == 1
+    close!(query)
+end
+
+@testset "Query entity component access unchecked" begin
+    world = TestWorld(Position, Velocity)
+
+    e1 = new_entity!(world, (Position(1, 2), Velocity(3, 4)))
+
+    query = Query(world, (Position, Velocity))
+    @unchecked begin
+        @test get_components(query, e1, (Position, Velocity)) == (Position(1, 2), Velocity(3, 4))
+        set_components!(query, e1, (Position(5, 6),))
+        @test get_components(query, e1, (Position,)) == (Position(5, 6),)
+        @test has_components(query, e1, (Position, Velocity)) == true
+    end
+    close!(query)
+end
+
+@testset "Query entity component access does not allocate" begin
+    world = TestWorld(Position, Velocity)
+
+    entities = [new_entity!(world, (Position(i, i), Velocity(1, 1))) for i in 1:100]
+
+    function query_entity_access!(query, entities)
+        s = 0.0
+        for e in entities
+            pos, vel = get_components(query, e, (Position, Velocity))
+            set_components!(query, e, (Position(pos.x + vel.dx, pos.y + vel.dy),))
+            s += pos.x
+        end
+        return s
+    end
+
+    query = Query(world, (Position, Velocity))
+    query_entity_access!(query, entities)
+    @test @allocated(query_entity_access!(query, entities)) == 0
+    close!(query)
+end

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -695,27 +695,23 @@ end
 
     query = Query(world, (Position, Velocity))
 
-    # getting
     @test get_components(query, e1, (Position, Velocity)) == (Position(1, 2), Velocity(3, 4))
     @test get_components(query, e1, (Velocity, Position)) == (Velocity(3, 4), Position(1, 2))
     @test get_components(query, e1, (Position,)) == (Position(1, 2),)
     @test get_components(query, e2, (Position, Velocity)) == (Position(5, 6), Velocity(7, 8))
     @test get_components(query, e1, ()) == ()
 
-    # checking
     @test has_components(query, e1, (Position, Velocity)) == true
     @test has_components(query, e3, (Position,)) == false
     @test has_components(query, e3, (Position, Velocity)) == false
     @test has_components(query, e1, ()) == true
 
-    # setting
     @test set_components!(query, e1, (Position(0, 0),)) == (Position(0, 0),)
     @test get_components(query, e1, (Position,)) == (Position(0, 0),)
     set_components!(query, e1, (Velocity(1, 1), Position(2, 2)))
     @test get_components(world, e1, (Position, Velocity)) == (Position(2, 2), Velocity(1, 1))
     @test set_components!(query, e1, ()) == ()
 
-    # inference (the component types are constant-folded)
     get_pos_vel(q, e) = get_components(q, e, (Position, Velocity))
     set_pos(q, e) = set_components!(q, e, (Position(2, 2),))
     has_pos_vel(q, e) = has_components(q, e, (Position, Velocity))
@@ -723,7 +719,6 @@ end
     @inferred set_pos(query, e1)
     @inferred has_pos_vel(query, e1)
 
-    # the operations above neither iterate nor close the query
     @test query._q_lock.closed == false
     @test is_locked(world) == true
     @test count_tables(world, query) == 2
@@ -822,7 +817,6 @@ end
         set_components!(query, e1, (Position(1, 1), Position(2, 2)))
     )
 
-    # the query is still usable
     @test get_components(query, e1, (Position, Velocity)) == (Position(1, 2), Velocity(3, 4))
     @test count_entities(world, query) == 1
     close!(query)

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -822,6 +822,35 @@ end
     close!(query)
 end
 
+@testset "Query entity component access requires a matching entity" begin
+    world = TestWorld(Position, Velocity, Altitude, Health, Relation{ChildOf})
+    parent1 = new_entity!(world, ())
+    parent2 = new_entity!(world, ())
+    matching = new_entity!(world, (Position(1, 2), Velocity(3, 4), ChildOf() => parent1))
+    missing_with = new_entity!(world, (Position(5, 6), ChildOf() => parent1))
+    excluded = new_entity!(world, (Position(7, 8), Velocity(9, 10), Altitude(11), ChildOf() => parent1))
+    extra_component = new_entity!(world, (Position(12, 13), Velocity(14, 15), Health(16)))
+    wrong_target = new_entity!(world, (Position(17, 18), Velocity(19, 20), ChildOf() => parent2))
+
+    query = Query(world, (Position,); with=(Velocity,))
+    @test get_components(query, matching, (Position,)) == (Position(1, 2),)
+    @test_throws("ArgumentError: entity does not match query", get_components(query, missing_with, (Position,)))
+    @test has_components(query, missing_with, (Position,)) == false
+    close!(query)
+
+    query = Query(world, (Position,); with=(Velocity,), without=(Altitude,))
+    @test_throws("ArgumentError: entity does not match query", set_components!(query, excluded, (Position(0, 0),)))
+    close!(query)
+
+    query = Query(world, (Position, Velocity); exclusive=true)
+    @test_throws("ArgumentError: entity does not match query", get_components(query, extra_component, (Position,)))
+    close!(query)
+
+    query = Query(world, (Position, ChildOf => parent1); with=(Velocity,))
+    @test_throws("ArgumentError: entity does not match query", get_components(query, wrong_target, (Position,)))
+    close!(query)
+end
+
 @testset "Query entity component access unchecked" begin
     world = TestWorld(Position, Velocity)
 

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -883,6 +883,11 @@ end
 
     query = Query(world, (Position, Velocity))
     query_entity_access!(query, entities)
-    @test @allocated(query_entity_access!(query, entities)) == 0
+    if VERSION >= v"1.11"
+        @test @allocated(query_entity_access!(query, entities)) == 0
+    else
+        @test @allocated(query_entity_access!(query, entities)) == 16
+    end
+
     close!(query)
 end

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -786,17 +786,17 @@ end
     query = Query(world, (Position, Velocity))
 
     @test_throws(
-        "ArgumentError: component Health is not part of the query (Position, Velocity)",
+        "ArgumentError: component Health is not part of the query on (Position, Velocity)",
         get_components(query, e1, (Health,))
     )
     @test_throws(
-        "ArgumentError: component Health is not part of the query (Position, Velocity)",
+        "ArgumentError: component Health is not part of the query on (Position, Velocity)",
         set_components!(query, e1, (Health(1),))
     )
     @test_throws("ArgumentError: entity has no Position component", get_components(query, e2, (Position,)))
     @test_throws("ArgumentError: entity has no Position component", set_components!(query, e2, (Position(1, 1),)))
     @test_throws(
-        "ArgumentError: component Health is not part of the query (Position, Velocity)",
+        "ArgumentError: component Health is not part of the query on (Position, Velocity)",
         has_components(query, e1, (Health,))
     )
     @test_throws("ArgumentError: can't get components of a dead entity", get_components(query, dead, (Position,)))

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -793,8 +793,8 @@ end
         "ArgumentError: component Health is not part of the query on (Position, Velocity)",
         set_components!(query, e1, (Health(1),))
     )
-    @test_throws("ArgumentError: entity has no Position component", get_components(query, e2, (Position,)))
-    @test_throws("ArgumentError: entity has no Position component", set_components!(query, e2, (Position(1, 1),)))
+    @test_throws("ArgumentError: entity does not match query", get_components(query, e2, (Position,)))
+    @test_throws("ArgumentError: entity does not match query", set_components!(query, e2, (Position(1, 1),)))
     @test_throws(
         "ArgumentError: component Health is not part of the query on (Position, Velocity)",
         has_components(query, e1, (Health,))


### PR DESCRIPTION
à la Bevy, which allows to access components of a single entity through queries (and from the world as was already implemented).